### PR TITLE
Add flatcar.autologin option which is the OEM default

### DIFF
--- a/packet.ipxe
+++ b/packet.ipxe
@@ -1,6 +1,6 @@
 #!ipxe
 
 set base-url https://stable.release.flatcar-linux.net/amd64-usr/current
-kernel ${base-url}/flatcar_production_pxe.vmlinuz initrd=flatcar_production_pxe_image.cpio.gz flatcar.first_boot=1 flatcar.oem.id=packet console=ttyS1,115200n8
+kernel ${base-url}/flatcar_production_pxe.vmlinuz initrd=flatcar_production_pxe_image.cpio.gz flatcar.first_boot=1 flatcar.oem.id=packet console=ttyS1,115200n8 flatcar.autologin
 initrd ${base-url}/flatcar_production_pxe_image.cpio.gz
 boot


### PR DESCRIPTION
When Flatcar is installed with the Packet OEM package,
this boot option will be added. Make autologin available
during the iPXE boot as well.

Note: After merging the tag for `amd64-usr` needs to be updated.